### PR TITLE
Add configurable options: Gate move/wait times and "stop" (invert)

### DIFF
--- a/custom_components/palgate/__init__.py
+++ b/custom_components/palgate/__init__.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN as PALGATE_DOMAIN, PLATFORMS, CONF_TOKEN_TYPE
+from .const import DOMAIN as PALGATE_DOMAIN
+from .const import *
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -35,7 +36,7 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
-    if config_entry.version > 2:
+    if config_entry.version > 3:
         return False
 
     new_data = dict(config_entry.data)
@@ -44,6 +45,15 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
         new_data[CONF_TOKEN_TYPE] = "1"
 
-    hass.config_entries.async_update_entry(config_entry, data=new_data, version=2)
+    if config_entry.version < 3:
+
+        new_data[CONF_ADVANCED] = {
+            CONF_SECONDS_TO_OPEN : SECONDS_TO_OPEN,
+            CONF_SECONDS_OPEN : SECONDS_OPEN,
+            CONF_SECONDS_TO_CLOSE : SECONDS_TO_CLOSE,
+            CONF_ALLOW_INVERT_AS_STOP : False
+        }
+
+    hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
 
     return True

--- a/custom_components/palgate/config_flow.py
+++ b/custom_components/palgate/config_flow.py
@@ -8,10 +8,11 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE_ID, CONF_TOKEN
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers.selector import selector
 
-from .const import DOMAIN as PALGATE_DOMAIN, CONF_PHONE_NUMBER, CONF_TOKEN_TYPE
+from .const import DOMAIN as PALGATE_DOMAIN
+from .const import *
 
 SCHEMA = vol.Schema(
     {
@@ -23,14 +24,25 @@ SCHEMA = vol.Schema(
                 "mode": "dropdown",
                 "options": ["0","1", "2"],
             }
-        })
+        }),
+        vol.Required("advanced_options"): section(
+            vol.Schema(
+                {
+                    vol.Required(CONF_SECONDS_TO_OPEN, default=SECONDS_TO_OPEN): int,
+                    vol.Required(CONF_SECONDS_OPEN, default=SECONDS_OPEN): int,
+                    vol.Required(CONF_SECONDS_TO_CLOSE, default=SECONDS_TO_CLOSE): int,
+                    vol.Required(CONF_ALLOW_INVERT_AS_STOP, default=False): bool,
+                }
+            ),
+            {"collapsed": True}
+        )
     }
 )
 
 class PollenvarselFlowHandler(config_entries.ConfigFlow, domain=PALGATE_DOMAIN):
     """Config flow for Palgate."""
 
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/palgate/const.py
+++ b/custom_components/palgate/const.py
@@ -10,6 +10,12 @@ PLATFORMS = ["cover"]
 CONF_PHONE_NUMBER = "phone_number"
 CONF_TOKEN_TYPE = "token_type"
 
+CONF_ADVANCED = "advanced_options"
+CONF_SECONDS_TO_OPEN = "seconds_to_open"
+CONF_SECONDS_OPEN = "seconds_open"
+CONF_SECONDS_TO_CLOSE = "seconds_to_close"
+CONF_ALLOW_INVERT_AS_STOP = "allow_invert_as_stop"
+
 SECONDS_TO_OPEN = 25
 SECONDS_OPEN = 45
 SECONDS_TO_CLOSE = 35

--- a/custom_components/palgate/cover.py
+++ b/custom_components/palgate/cover.py
@@ -40,6 +40,10 @@ async def async_setup_entry(
         token=entry.data[CONF_TOKEN],
         token_type=entry.data[CONF_TOKEN_TYPE],
         phone_number=entry.data[CONF_PHONE_NUMBER],
+        seconds_to_open=entry.data[CONF_ADVANCED][CONF_SECONDS_TO_OPEN],
+        seconds_open=entry.data[CONF_ADVANCED][CONF_SECONDS_OPEN],
+        seconds_to_close=entry.data[CONF_ADVANCED][CONF_SECONDS_TO_CLOSE],
+        allow_invert_as_stop=entry.data[CONF_ADVANCED][CONF_ALLOW_INVERT_AS_STOP],
         session=async_get_clientsession(hass),
     )
         
@@ -88,3 +92,8 @@ class PalgateCover(CoverEntity):
         """Open the cover."""
 
         await self.api.open_gate()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover - only if allowed in config (usually auto-close)"""
+
+        await self.api.invert_gate()

--- a/custom_components/palgate/generate_linked_device_session_token
+++ b/custom_components/palgate/generate_linked_device_session_token
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Helper for generating a Palgate token inside the HA terminal shell.
+# Requires Internet access from HA.
+#
+# @doron1 2025, v0.1
+
+PACKAGE="git+https://github.com/DonutByte/pylgate.git@main"
+SCRIPT="generate_linked_device_session_token.py"
+SCRIPT_LOCATION="https://raw.githubusercontent.com/DonutByte/pylgate/refs/heads/main/examples"
+
+Main () {
+
+trap Cleanup EXIT
+
+VENV_ACTIVATED=false
+TMPDIR=$(mktemp -dp . || FailWith "Unable to create temp dir")
+
+echo -e "\nPlease open the Palgate app on your phone, select \"Link Devices\" from the menu,"
+echo -e "and wait for the QR code to appear here, this may take a few moments."
+echo -e "When it appears, select \"Link A Device\" and scan the QR code.\n"
+echo -e "When done, copy the phone num, token and token type, you will need them when configuring the integration.\n"
+
+python -m venv $TMPDIR > /dev/null || FailWith "Unable to create Python venv"
+
+source $TMPDIR/bin/activate
+VENV_ACTIVATED=true
+
+# Bring in the good stuff from DonutByte
+pip -q install $PACKAGE > /dev/null || FailWith "Unable to install token generation program"
+wget -P $TMPDIR $SCRIPT_LOCATION/$SCRIPT > /dev/null 2>&1
+
+pip -q install qrcode requests > /dev/null
+
+python $TMPDIR/$SCRIPT
+
+}
+
+FailWith () {
+
+  echo "Error: $*"
+  exit 1
+
+}
+
+Cleanup () {
+
+  echo "Cleaning up"
+  $VENV_ACTIVATED && deactivate
+  rm -fr $TMPDIR
+
+}
+
+Main $*

--- a/custom_components/palgate/strings.json
+++ b/custom_components/palgate/strings.json
@@ -12,6 +12,21 @@
           "phone_number": "Phone number registered with Palgate",
           "token": "Token generated using Link Devices (see integration documentation)",
           "token_type": "1 or 2 for the first or second Linked Device on the Palgate app. 0 is for SMS-derived links"
+        },
+        "sections": {
+            "advanced_options": {
+                "name": "Advanced Options",
+                "description": "If you are unsure, leave at default values",
+                "data": {
+                    "time_to_open": "Time (sec) gate takes to open",
+                    "time_open": "Time (sec) gate remains open",
+                    "time_to_close": "Time (sec) gate takes to close",
+                    "allow_invert_as_stop": "Allow triggering gate while opening, to invert direction"
+                },
+                "data_descrtiption": {
+                    "allow_invert_as_stop": "If selected, STOP will trigger the gate again during open"
+                }
+            }
         }
       }
     },

--- a/custom_components/palgate/translations/en.json
+++ b/custom_components/palgate/translations/en.json
@@ -20,6 +20,21 @@
                     "phone_number": "Phone number registered with Palgate",
                     "token": "Token generated using Link Devices (see integration documentation)",
                     "token_type": "1 or 2 for the first or second Linked Device on the Palgate app. 0 is for SMS-derived links"
+                },
+                "sections": {
+                    "advanced_options": {
+                        "name": "Advanced Options",
+                        "description": "If you are unsure, leave at default values",
+                        "data": {
+                            "time_to_open": "Time (sec) gate takes to open",
+                            "time_open": "Time (sec) gate remains open",
+                            "time_to_close": "Time (sec) gate takes to close",
+                            "allow_invert_as_stop": "Allow triggering gate while opening, to invert direction"
+                        },
+                        "data_descrtiption": {
+                            "allow_invert_as_stop": "If selected, STOP will trigger the gate again during open"
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Configurable options for gate open / stay open / close times, and an option to allow the "cover stop" button to serve as "invert" (in fact, trigger the gate again when not closed, to invert its movement).

Also added a CLI script to make the token generation even easier - I see some folks still struggling with it.
Usage: Go to HA CLI terminal
cd /config/custom_components/palgate
./generate_linked_device_session_token

Closes #7