### PR TITLE
Fix a typo in ee105c5, causing UI field names to show internal names

### DIFF
--- a/custom_components/palgate/strings.json
+++ b/custom_components/palgate/strings.json
@@ -18,9 +18,9 @@
                 "name": "Advanced Options",
                 "description": "If you are unsure, leave at default values",
                 "data": {
-                    "time_to_open": "Time (sec) gate takes to open",
-                    "time_open": "Time (sec) gate remains open",
-                    "time_to_close": "Time (sec) gate takes to close",
+                    "seconds_to_open": "Time (sec) gate takes to open",
+                    "seconds_open": "Time (sec) gate remains open",
+                    "seconds_to_close": "Time (sec) gate takes to close",
                     "allow_invert_as_stop": "Allow triggering gate while opening, to invert direction"
                 },
                 "data_description": {

--- a/custom_components/palgate/translations/en.json
+++ b/custom_components/palgate/translations/en.json
@@ -26,9 +26,9 @@
                         "name": "Advanced Options",
                         "description": "If you are unsure, leave at default values",
                         "data": {
-                            "time_to_open": "Time (sec) gate takes to open",
-                            "time_open": "Time (sec) gate remains open",
-                            "time_to_close": "Time (sec) gate takes to close",
+                            "seconds_to_open": "Time (sec) gate takes to open",
+                            "seconds_open": "Time (sec) gate remains open",
+                            "seconds_to_close": "Time (sec) gate takes to close",
                             "allow_invert_as_stop": "Allow triggering gate while opening, to invert direction"
                         },
                         "data_description": {


### PR DESCRIPTION
Due to a typo in ee105c5 (Add configurable options: Gate move/wait times and "stop" (invert) (#8), 2025-02-22), "advanced" configuration fields do not show their string descriptions, but their internal names